### PR TITLE
ES-1602 Update prereq versions in corda-dev-prereqs Helm chart

### DIFF
--- a/charts/corda-dev-prereqs/Chart.yaml
+++ b/charts/corda-dev-prereqs/Chart.yaml
@@ -3,5 +3,5 @@ name: corda-dev-prereqs
 description: A Helm chart for installing Corda 5 development pre-requisites (Kafka and PostgreSQL)
 
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "5.0.0"

--- a/charts/corda-dev-prereqs/Chart.yaml
+++ b/charts/corda-dev-prereqs/Chart.yaml
@@ -3,5 +3,5 @@ name: corda-dev-prereqs
 description: A Helm chart for installing Corda 5 development pre-requisites (Kafka and PostgreSQL)
 
 type: application
-version: 0.2.1
+version: 0.3.0
 appVersion: "5.0.0"

--- a/charts/corda-dev-prereqs/templates/kafka/kafka-statefulset.yaml
+++ b/charts/corda-dev-prereqs/templates/kafka/kafka-statefulset.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: "kafka"
-          image: "{{ .Values.imageRegistry }}/confluentinc/cp-kafka:7.3.3"
+          image: "{{ .Values.imageRegistry }}/confluentinc/cp-kafka:7.5.3"
           env:
             - name: "KAFKA_ENABLE_KRAFT"
               value: "yes"

--- a/charts/corda-dev-prereqs/templates/postgres/postgres-deployment.yaml
+++ b/charts/corda-dev-prereqs/templates/postgres/postgres-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: "postgres"
-          image: "{{ .Values.imageRegistry }}/postgres:14"
+          image: "{{ .Values.imageRegistry }}/postgres:16.1"
           args: ["-c", "max_connections={{ .Values.maxConnections }}"]
           env:
             - name: "POSTGRES_DB"

--- a/charts/corda-dev-prereqs/templates/tests/kafka-test.yaml
+++ b/charts/corda-dev-prereqs/templates/tests/kafka-test.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
     - name: "kafka"
-      image: "{{ .Values.imageRegistry }}/confluentinc/cp-kafka:7.2.3"
+      image: "{{ .Values.imageRegistry }}/confluentinc/cp-kafka:7.5.3"
       volumeMounts:
         - mountPath: "/certs"
           name: "certs"

--- a/charts/corda-dev-prereqs/templates/tests/postgres-test.yaml
+++ b/charts/corda-dev-prereqs/templates/tests/postgres-test.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
     - name: "postgresql"
-      image: "{{ .Values.imageRegistry }}/postgres:14"
+      image: "{{ .Values.imageRegistry }}/postgres:16.1"
       env:
         - name: "PGPASSWORD"
           valueFrom:


### PR DESCRIPTION
Postgres:           14.1 -> 16.1
Kafka:                7.3.3 / 7.2.3 -> 7.5.3
Chart Version:   0.2.0 -> 0.3.0