### PR TITLE
ES-1801: Updating Kafka version as Confluent supports Kafka 3.6

### DIFF
--- a/charts/corda-dev-prereqs/templates/kafka/kafka-statefulset.yaml
+++ b/charts/corda-dev-prereqs/templates/kafka/kafka-statefulset.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: "kafka"
-          image: "{{ .Values.imageRegistry }}/confluentinc/cp-kafka:7.5.3"
+          image: "{{ .Values.imageRegistry }}/confluentinc/cp-kafka:7.6.1"
           env:
             - name: "KAFKA_ENABLE_KRAFT"
               value: "yes"

--- a/charts/corda-dev-prereqs/templates/tests/kafka-test.yaml
+++ b/charts/corda-dev-prereqs/templates/tests/kafka-test.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
     - name: "kafka"
-      image: "{{ .Values.imageRegistry }}/confluentinc/cp-kafka:7.5.3"
+      image: "{{ .Values.imageRegistry }}/confluentinc/cp-kafka:7.6.1"
       volumeMounts:
         - mountPath: "/certs"
           name: "certs"


### PR DESCRIPTION
**Description**
Updating confluentinc/cp-kafka to 7.6.1 in kafka-test.yml and kafka-stateful.yml